### PR TITLE
Bug fix on result code of ofxZmqSocket::send()

### DIFF
--- a/example/super_simple_pub_sub/testApp.cpp
+++ b/example/super_simple_pub_sub/testApp.cpp
@@ -35,7 +35,10 @@ void testApp::draw()
 //--------------------------------------------------------------
 void testApp::keyPressed(int key)
 {
-	publisher.send("this is a test");
+	if (!publisher.send("this is a test"))
+	{
+		cout << "send failed" << endl;
+	}
 }
 
 //--------------------------------------------------------------

--- a/src/ofxZmqSocket.cpp
+++ b/src/ofxZmqSocket.cpp
@@ -49,8 +49,7 @@ bool ofxZmqSocket::send(const void *data, size_t len, bool nonblocking, bool mor
 	
 	try
 	{
-		int rc = socket.send(m, flags);
-		return rc == 0;
+		return socket.send(m, flags);
 	}
 	catch (zmq::error_t &e)
 	{


### PR DESCRIPTION
zmq::socket_t::send() returns boolean value which represent if the
operation is successfully finished. So all ofxZmqSocket::send() have to
do is bypass the result to the caller.
